### PR TITLE
update to Scala 2.12 and sbt 1.1

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,4 @@
+-J-Xms2048m
+-J-Xmx2048m
+-J-XX:ReservedCodeCacheSize=256m
+-J-XX:MaxMetaspaceSize=512m

--- a/admin/build.sh
+++ b/admin/build.sh
@@ -16,9 +16,9 @@ if [[ "$TRAVIS_TAG" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?(-[A-Za-z0-9-]+)? ]]; then
   openssl aes-256-cbc -K $encrypted_950849751342_key -iv $encrypted_950849751342_iv -in secrets.tar.enc -out secrets.tar -d
   myVer=$(echo $TRAVIS_TAG | sed -e s/^v//)
   publishVersion='set every version := "'$myVer'"'
-  extraTarget="publishSigned"
+  extraTarget="+publishSigned"
   cp admin/publish-settings.sbt ./
   tar xf secrets.tar
 fi
 
-sbt "$publishVersion" test makeSite scripted publishLocal $extraTarget
+sbt "$publishVersion" +test +makeSite +scripted +publishLocal $extraTarget

--- a/build.sbt
+++ b/build.sbt
@@ -4,11 +4,11 @@ val makeSite = TaskKey[Unit]("makeSite")
 lazy val root = project.in(file("."))
   .aggregate(core, plugin)
   .dependsOn(core)
-  .disablePlugins(BintrayPlugin)
+  .disablePlugins(BintrayPlugin, ScriptedPlugin)
   .settings(inThisBuild(Seq(
     organization := "com.novocode",
     version := "0.5-SNAPSHOT",
-    scalaVersion := "2.11.8",
+    scalaVersion := "2.12.8",
     scalacOptions ++= Seq("-deprecation", "-unchecked"),
     homepage := Some(url("https://szeiger.github.io/ornate-doc/")),
     scmInfo := Some(ScmInfo(url("https://github.com/szeiger/ornate"), "git@github.com:szeiger/ornate.git")),
@@ -20,12 +20,12 @@ lazy val root = project.in(file("."))
     licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
   )))
   .settings(
-    makeDoc := (Def.taskDyn {
+    makeDoc := Def.taskDyn {
       val v = version.value
       val tag = if(v.endsWith("-SNAPSHOT")) "master" else "v"+v
       val args = s""" com.novocode.ornate.Main "-Dversion=$v" "-Dtag=$tag" doc/ornate.conf"""
       (runMain in Compile).toTask(args)
-    }).value,
+    }.value,
     publishArtifact := false,
     publish := {},
     publishLocal := {},
@@ -44,6 +44,7 @@ val commonMarkVersion = "0.7.1"
 
 lazy val core = project.in(file("core"))
   .enablePlugins(SbtTwirl)
+  .disablePlugins(ScriptedPlugin)
   .settings(
     name := "ornate",
     libraryDependencies ++= Seq(
@@ -55,8 +56,8 @@ lazy val core = project.in(file("core"))
       "com.typesafe" % "config" % "1.3.0",
       "org.slf4j" % "slf4j-api" % "1.7.18",
       "org.scala-lang.modules" %% "scala-xml" % "1.0.5",
-      "com.github.pathikrit" %% "better-files" % "2.16.0",
-      "com.typesafe.play" %% "play-json" % "2.5.5",
+      "com.github.pathikrit" %% "better-files" % "2.17.1",
+      "com.typesafe.play" %% "play-json" % "2.6.9",
       "org.webjars" % "webjars-locator-core" % "0.31",
       "org.webjars.npm" % "highlight.js" % "9.6.0",
       "org.webjars.npm" % "emojione" % "2.2.6",
@@ -83,10 +84,8 @@ lazy val plugin = project.in(file("plugin"))
   .settings(
     name := "sbt-ornate",
     sbtPlugin := true,
-    scalaVersion := "2.10.6",
-    buildInfoKeys := Seq[BuildInfoKey](organization, (name in core), version, (scalaVersion in core)),
+    buildInfoKeys := Seq[BuildInfoKey](organization, name in core, version, scalaVersion in core),
     buildInfoPackage := "com.novocode.ornate.sbtplugin",
-    scriptedSettings,
     scriptedLaunchOpts ++= Seq("-Xmx1024M", "-Dplugin.version=" + version.value),
     scriptedBufferLog := false,
     scriptedDependencies := { val _ = ((publishLocal in core).value, publishLocal.value) },

--- a/core/src/main/scala/com/novocode/ornate/commonmark/SuperscriptExtension.scala
+++ b/core/src/main/scala/com/novocode/ornate/commonmark/SuperscriptExtension.scala
@@ -31,7 +31,7 @@ abstract class SuperscriptSubscriptExtension[T <: Node : ClassTag] extends Exten
   def tag: String
   val ext = Seq(new Parser.ParserExtension {
     override def extend(builder: Parser.Builder): Unit =
-      builder.customDelimiterProcessor(new SuperscriptSubscriptDelimiterProcessor(delim)(create))
+      builder.customDelimiterProcessor(new SuperscriptSubscriptDelimiterProcessor(delim)(() => SuperscriptSubscriptExtension.this.create()))
   })
   override def parserExtensions(pageConfig: Config) = ext
   override val htmlRendererExtensions: Seq[HtmlRenderer.HtmlRendererExtension] = Seq(

--- a/core/src/main/scala/com/novocode/ornate/js/ElasticlunrSearch.scala
+++ b/core/src/main/scala/com/novocode/ornate/js/ElasticlunrSearch.scala
@@ -1,8 +1,7 @@
 package com.novocode.ornate.js
 
 import com.novocode.ornate.Logging
-import play.api.libs.json.{JsArray, JsObject, JsString}
-import play.libs.Json
+import play.api.libs.json.{JsArray, JsString}
 
 import scala.collection.mutable
 

--- a/core/src/main/twirl/com/novocode/ornate/theme/default/app_css.scala.txt
+++ b/core/src/main/twirl/com/novocode/ornate/theme/default/app_css.scala.txt
@@ -1,3 +1,4 @@
+@this()
 @(m: com.novocode.ornate.theme.default.DefaultSiteModel)
 
 body {

--- a/core/src/main/twirl/com/novocode/ornate/theme/default/default.scala.html
+++ b/core/src/main/twirl/com/novocode/ornate/theme/default/default.scala.html
@@ -1,2 +1,3 @@
+@this()
 @(p: com.novocode.ornate.theme.default.DefaultPageModel)
 @main(p)(p.content)()

--- a/core/src/main/twirl/com/novocode/ornate/theme/default/main.scala.html
+++ b/core/src/main/twirl/com/novocode/ornate/theme/default/main.scala.html
@@ -1,4 +1,4 @@
-@(p: com.novocode.ornate.theme.default.DefaultPageModel)(content: Html)(footer: Html = HtmlFormat.empty)
+@(p: com.novocode.ornate.theme.default.DefaultPageModel)(content: Html)(footer: Html = play.twirl.api.HtmlFormat.empty)
 @import com.novocode.ornate.theme.default.DefaultTheme
 @import com.novocode.ornate.theme.HtmlFeatures
 
@@ -146,10 +146,10 @@
         <div class="row">
           <div class="small-12 medium-12 large-12 columns top-bar">
             <div class="top-bar-left">
-              @{p.stringHtml("footerLeft").getOrElse(HtmlFormat.empty)}
+              @{p.stringHtml("footerLeft").getOrElse(play.twirl.api.HtmlFormat.empty)}
             </div>
             <div class="top-bar-right">
-              @{p.stringHtml("footerRight").getOrElse(HtmlFormat.empty)}
+              @{p.stringHtml("footerRight").getOrElse(play.twirl.api.HtmlFormat.empty)}
             </div>
           </div>
         </div>

--- a/core/src/main/twirl/com/novocode/ornate/theme/default/search.scala.html
+++ b/core/src/main/twirl/com/novocode/ornate/theme/default/search.scala.html
@@ -1,3 +1,4 @@
+@this()
 @(p: com.novocode.ornate.theme.default.DefaultPageModel)
 @import com.novocode.ornate.theme.HtmlFeatures
 @main(p) {

--- a/plugin/src/main/scala/com/novocode/ornate/sbtplugin/OrnatePlugin.scala
+++ b/plugin/src/main/scala/com/novocode/ornate/sbtplugin/OrnatePlugin.scala
@@ -33,7 +33,7 @@ object OrnatePlugin extends AutoPlugin {
     scalaVersion in Ornate := BuildInfo.scalaVersion,
     ivyConfigurations += Ornate,
     libraryDependencies ++= Seq(
-      BuildInfo.organization % (BuildInfo.name+"_2.11") % BuildInfo.version % Ornate,
+      BuildInfo.organization %% BuildInfo.name % BuildInfo.version % Ornate,
       "org.scala-lang" % "scala-library" % BuildInfo.scalaVersion % Ornate
     )
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=1.1.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.1.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.3.15")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.8.0")
 
-libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.3")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")


### PR DESCRIPTION
This should cross-publish for Scala 2.11 and 2.12, but only with sbt 1. Hopefully losing sbt 0.13 support is acceptable.

This would fix #14 and supersedes #12.