### PR TITLE
Cross compile library for 2.11, 2.12, 2.13.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 sudo: false
-addons:
-  apt:
-    packages:
-    - oracle-java8-installer
 language: scala
 jdk:
-- oraclejdk8
+- openjdk8
 script:
 - admin/build.sh

--- a/build.sbt
+++ b/build.sbt
@@ -3,12 +3,11 @@ val makeSite = TaskKey[Unit]("makeSite")
 
 lazy val root = project.in(file("."))
   .aggregate(core, plugin)
-  .dependsOn(core)
   .disablePlugins(BintrayPlugin, ScriptedPlugin)
   .settings(inThisBuild(Seq(
     organization := "com.novocode",
     version := "0.5-SNAPSHOT",
-    scalaVersion := "2.12.8",
+    scalaVersion := "2.12.11",
     scalacOptions ++= Seq("-deprecation", "-unchecked"),
     homepage := Some(url("https://szeiger.github.io/ornate-doc/")),
     scmInfo := Some(ScmInfo(url("https://github.com/szeiger/ornate"), "git@github.com:szeiger/ornate.git")),
@@ -20,24 +19,10 @@ lazy val root = project.in(file("."))
     licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
   )))
   .settings(
-    makeDoc := Def.taskDyn {
-      val v = version.value
-      val tag = if(v.endsWith("-SNAPSHOT")) "master" else "v"+v
-      val args = s""" com.novocode.ornate.Main "-Dversion=$v" "-Dtag=$tag" doc/ornate.conf"""
-      (runMain in Compile).toTask(args)
-    }.value,
     publishArtifact := false,
     publish := {},
     publishLocal := {},
-    PgpKeys.publishSigned := {},
-    makeSite := {
-      makeDoc.value
-      val target = file("doc/target/api")
-      IO.delete(target)
-      IO.createDirectory(target)
-      val api = (doc in Compile in core).value
-      IO.copyDirectory(api, target)
-    }
+    PgpKeys.publishSigned := {}
   )
 
 val commonMarkVersion = "0.7.1"
@@ -47,6 +32,8 @@ lazy val core = project.in(file("core"))
   .disablePlugins(ScriptedPlugin)
   .settings(
     name := "ornate",
+    crossScalaVersions := Seq("2.12.11", "2.13.1", "2.11.12"),
+    scalaVersion := crossScalaVersions.value.head,
     libraryDependencies ++= Seq(
       "com.atlassian.commonmark" % "commonmark" % commonMarkVersion,
       "com.atlassian.commonmark" % "commonmark-ext-gfm-tables" % commonMarkVersion,
@@ -55,9 +42,10 @@ lazy val core = project.in(file("core"))
       "com.atlassian.commonmark" % "commonmark-ext-ins" % commonMarkVersion,
       "com.typesafe" % "config" % "1.3.0",
       "org.slf4j" % "slf4j-api" % "1.7.18",
-      "org.scala-lang.modules" %% "scala-xml" % "1.0.5",
-      "com.github.pathikrit" %% "better-files" % "2.17.1",
-      "com.typesafe.play" %% "play-json" % "2.6.9",
+      "org.scala-lang.modules" %% "scala-xml" % "1.3.0",
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.4",
+      "com.github.pathikrit" %% "better-files" % "3.8.0",
+      "com.typesafe.play" %% "play-json" % "2.7.4",
       "org.webjars" % "webjars-locator-core" % "0.31",
       "org.webjars.npm" % "highlight.js" % "9.6.0",
       "org.webjars.npm" % "emojione" % "2.2.6",
@@ -76,11 +64,26 @@ lazy val core = project.in(file("core"))
     ),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v", "-s", "-a"),
     fork in Test := true,
-    parallelExecution in Test := false
+    parallelExecution in Test := false,
+    makeDoc := Def.taskDyn {
+      val v = version.value
+      val tag = if(v.endsWith("-SNAPSHOT")) "master" else "v"+v
+      val args = s""" com.novocode.ornate.Main "-Dversion=$v" "-Dtag=$tag" doc/ornate.conf"""
+      (runMain in Compile).toTask(args)
+    }.value,
+    makeSite := {
+      makeDoc.value
+      val target = file("doc/target/api")
+      IO.delete(target)
+      IO.createDirectory(target)
+      val api = (doc in Compile).value
+      IO.copyDirectory(api, target)
+    },
+    scripted := {}
   )
 
 lazy val plugin = project.in(file("plugin"))
-  .enablePlugins(BuildInfoPlugin)
+  .enablePlugins(BuildInfoPlugin, ScriptedPlugin)
   .settings(
     name := "sbt-ornate",
     sbtPlugin := true,

--- a/core/src/main/scala/com/novocode/ornate/EmojiExtension.scala
+++ b/core/src/main/scala/com/novocode/ornate/EmojiExtension.scala
@@ -43,7 +43,7 @@ class EmojiParserExtension(co: ConfiguredObject) extends Parser.ParserExtension 
         case Some("") => None
         case o => o
       }
-      val e = EmojiData(names, unicode +: unicodeAlt.toVector)
+      val e = EmojiData(names.toSeq, unicode +: unicodeAlt.toVector)
       e.names.map(n => (n, e))
     }.toMap
   }
@@ -95,7 +95,7 @@ class EmojiParserExtension(co: ConfiguredObject) extends Parser.ParserExtension 
       }
       i += 1
     }
-    if(buf eq null) Vector.empty else buf
+    if(buf eq null) Vector.empty else buf.toIndexedSeq
   }
 
   def replaceEmojis(s: String): Option[IndexedSeq[Replacement]] = {
@@ -121,7 +121,7 @@ class EmojiParserExtension(co: ConfiguredObject) extends Parser.ParserExtension 
           buf += data
         }
         if(len > copied) buf += PlainText(s.substring(copied, len))
-        Some(buf)
+        Some(buf.toIndexedSeq)
       }
     }
   }

--- a/core/src/main/scala/com/novocode/ornate/ExternalLinksExtension.scala
+++ b/core/src/main/scala/com/novocode/ornate/ExternalLinksExtension.scala
@@ -6,7 +6,7 @@ import com.novocode.ornate.config.ConfigExtensionMethods.configExtensionMethods
 import com.typesafe.config.{Config, ConfigObject}
 import org.commonmark.node.{AbstractVisitor, Link, Text}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /** Translate generic external links */
 class ExternalLinksExtension(co: ConfiguredObject) extends Extension with Logging {

--- a/core/src/main/scala/com/novocode/ornate/FileMatcher.scala
+++ b/core/src/main/scala/com/novocode/ornate/FileMatcher.scala
@@ -5,7 +5,7 @@ import java.util.regex.Pattern
 import better.files._
 
 /** Pattern matcher for gitignore-style patterns */
-class FileMatcher(val patterns: Traversable[String]) {
+class FileMatcher(val patterns: Iterable[String]) {
   case class Entry(pattern: String, compiled: Pattern, negate: Boolean, dirOnly: Boolean)
 
   def this(gitignore: String) =
@@ -14,7 +14,7 @@ class FileMatcher(val patterns: Traversable[String]) {
       t.nonEmpty && !t.startsWith("#")
     }.toVector)
 
-  val entries: Vector[Entry] = patterns.map(build)(collection.breakOut)
+  val entries: Vector[Entry] = patterns.map(build).toVector
 
   private def build(pattern: String): Entry = {
     var p = pattern

--- a/core/src/main/scala/com/novocode/ornate/GlobalRefsExtension.scala
+++ b/core/src/main/scala/com/novocode/ornate/GlobalRefsExtension.scala
@@ -4,7 +4,7 @@ import com.novocode.ornate.config.ConfiguredObject
 import com.novocode.ornate.config.ConfigExtensionMethods.configExtensionMethods
 import com.typesafe.config.{ConfigObject, Config}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /** Prepend global reference definitions to all pages */
 class GlobalRefsExtension(co: ConfiguredObject) extends Extension with Logging {

--- a/core/src/main/scala/com/novocode/ornate/IncludeCodeExtension.scala
+++ b/core/src/main/scala/com/novocode/ornate/IncludeCodeExtension.scala
@@ -142,7 +142,7 @@ class IncludeCodeExtension(co: ConfiguredObject) extends Extension with Logging 
           } else if(inBlock && !remove.exists(p => p.matcher(s).matches())) blockBuf += s
         }
         if(inBlock) endBlock(0)
-        if(found) Some(Snippet(buf.mkString("\n"), Some(linenos))) else None
+        if(found) Some(Snippet(buf.mkString("\n"), Some(linenos.toSeq))) else None
       }
     }
   }

--- a/core/src/main/scala/com/novocode/ornate/PageParser.scala
+++ b/core/src/main/scala/com/novocode/ornate/PageParser.scala
@@ -1,6 +1,7 @@
 package com.novocode.ornate
 
 import java.net.URI
+import java.nio.charset.StandardCharsets
 
 import com.novocode.ornate.commonmark.{AttributedHeading, CustomParser, CustomParserBuilder, NodeUtil}
 import com.novocode.ornate.commonmark.NodeExtensionMethods._
@@ -12,7 +13,7 @@ import org.commonmark.parser.Parser
 import better.files._
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.io.Codec
@@ -24,7 +25,7 @@ object PageParser extends Logging {
     logTime("Parsing took") {
       global.parMap(sources) { case (f, suffix, uri) =>
         logger.debug(s"Parsing $f as $uri")
-        try Some(parseWithFrontMatter(Some(f.uri), syntheticNames.get(uri), global.userConfig, uri, suffix, f.contentAsString(Codec.UTF8)))
+        try Some(parseWithFrontMatter(Some(f.uri), syntheticNames.get(uri), global.userConfig, uri, suffix, f.contentAsString(StandardCharsets.UTF_8)))
         catch { case ex: Exception =>
           logger.error(s"Error parsing $f -- skipping file", ex)
           None
@@ -35,7 +36,7 @@ object PageParser extends Logging {
 
   def parseWithFrontMatter(sourceFileURI: Option[URI], syntheticName: Option[String],
                            globalConfig: ReferenceConfig, uri: URI, suffix: String, text: String): Page = {
-    val lines = text.lines
+    val lines = text.linesIterator
     val (front, content) = if(lines.hasNext && lines.next.trim == "---") {
       var foundEnd = false
       val front = lines.takeWhile { s =>

--- a/core/src/main/scala/com/novocode/ornate/ScaladocLinksExtension.scala
+++ b/core/src/main/scala/com/novocode/ornate/ScaladocLinksExtension.scala
@@ -5,7 +5,7 @@ import com.novocode.ornate.config.ConfiguredObject
 import com.typesafe.config.{Config, ConfigObject}
 import org.commonmark.node.{AbstractVisitor, Link, Text}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /** Translate scaladoc links */
 class ScaladocLinksExtension(co: ConfiguredObject) extends Extension with Logging {

--- a/core/src/main/scala/com/novocode/ornate/Util.scala
+++ b/core/src/main/scala/com/novocode/ornate/Util.scala
@@ -9,8 +9,9 @@ import com.googlecode.htmlcompressor.compressor.{ClosureJavaScriptCompressor, Co
 import com.novocode.ornate.js.CSSO
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import java.net.{URI, URL, URLEncoder}
+import java.nio.charset.StandardCharsets
 import java.util.Locale
 
 import better.files._
@@ -106,7 +107,7 @@ object Util {
 
   def readLines(source: URL): Vector[String] = {
     val in = source.openStream()
-    try in.lines(Codec.UTF8).to[Vector] finally in.close
+    try in.lines(StandardCharsets.UTF_8).toVector finally in.close
   }
 
   def closureMinimize(source: String, name: String = "<eval>"): String = {

--- a/core/src/main/scala/com/novocode/ornate/commonmark/AttributeFencedCodeBlocksProcessor.scala
+++ b/core/src/main/scala/com/novocode/ornate/commonmark/AttributeFencedCodeBlocksProcessor.scala
@@ -83,7 +83,7 @@ class AttributedFencedCodeBlock extends FencedCodeBlock with Attributed {
         i = s.indexOf(pre, start)
       }
       if(s.length > 0) res += Left(s)
-      res
+      res.toSeq
     }
   }
 }

--- a/core/src/main/scala/com/novocode/ornate/commonmark/CustomParserBuilder.scala
+++ b/core/src/main/scala/com/novocode/ornate/commonmark/CustomParserBuilder.scala
@@ -3,7 +3,7 @@ package com.novocode.ornate.commonmark
 import java.io.Reader
 import java.util.Arrays
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import org.commonmark._
 import org.commonmark.internal._
 import org.commonmark.internal.inline.{AsteriskDelimiterProcessor, UnderscoreDelimiterProcessor}

--- a/core/src/main/scala/com/novocode/ornate/commonmark/MathSyntaxExtension.scala
+++ b/core/src/main/scala/com/novocode/ornate/commonmark/MathSyntaxExtension.scala
@@ -219,7 +219,7 @@ class MathSyntaxParserExtension(co: ConfiguredObject, pageConfig: Config) extend
     }
     if(start != -1) b.append(s.substring(start-delim)) // unterminated sequence
     if(b.nonEmpty) res += b.result()
-    res
+    res.toSeq
   }
 }
 

--- a/core/src/main/scala/com/novocode/ornate/commonmark/SimpleHtmlNodeRenderer.scala
+++ b/core/src/main/scala/com/novocode/ornate/commonmark/SimpleHtmlNodeRenderer.scala
@@ -4,7 +4,7 @@ import org.commonmark.renderer.NodeRenderer
 import org.commonmark.renderer.html.{HtmlNodeRendererContext, HtmlNodeRendererFactory}
 import org.commonmark.node.Node
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
 case class SimpleHtmlNodeRenderer[T <: Node : ClassTag, U](f: (T, HtmlNodeRendererContext) => U) extends HtmlNodeRendererFactory {

--- a/core/src/main/scala/com/novocode/ornate/config/ConfigExtensionMethods.scala
+++ b/core/src/main/scala/com/novocode/ornate/config/ConfigExtensionMethods.scala
@@ -5,7 +5,7 @@ import java.util.Properties
 import com.typesafe.config._
 import play.api.libs.json.Json
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /** Extension methods to make Typesafe Config easier to use */
 class ConfigExtensionMethods(val c: Config) extends AnyVal {
@@ -13,8 +13,8 @@ class ConfigExtensionMethods(val c: Config) extends AnyVal {
   def getIntOr(path: String, default: => Int = 0) = if(c.hasPath(path)) c.getInt(path) else default
   def getStringOr(path: String, default: => String = null) = if(c.hasPath(path)) c.getString(path) else default
   def getConfigOr(path: String, default: => Config = ConfigFactory.empty()) = if(c.hasPath(path)) c.getConfig(path) else default
-  def getStringListOr(path: String, default: => Seq[String] = Vector.empty): Seq[String] = if(c.hasPath(path)) c.getStringList(path).asScala else default
-  def getConfigListOr(path: String, default: => Seq[Config] = Vector.empty): Seq[Config] = if(c.hasPath(path)) c.getConfigList(path).asScala else default
+  def getStringListOr(path: String, default: => Seq[String] = Vector.empty): Seq[String] = if(c.hasPath(path)) c.getStringList(path).asScala.toSeq else default
+  def getConfigListOr(path: String, default: => Seq[Config] = Vector.empty): Seq[Config] = if(c.hasPath(path)) c.getConfigList(path).asScala.toSeq else default
   def getConfigMapOr(path: String, default: => Map[String, ConfigValue] = Map.empty): Map[String, ConfigValue] =
     if(c.hasPath(path)) c.getObject(path).entrySet().asScala.iterator.map(e => (e.getKey, e.getValue)).toMap else default
 
@@ -23,7 +23,7 @@ class ConfigExtensionMethods(val c: Config) extends AnyVal {
   def getIntOpt(path: String): Option[Int] = if(c.hasPath(path)) Some(c.getInt(path)) else None
   def getStringOpt(path: String) = Option(getStringOr(path))
   def getConfigOpt(path: String): Option[Config] = Option(getConfigOr(path, null))
-  def getListOpt(path: String): Option[Seq[ConfigValue]] = if(c.hasPath(path)) Some(c.getList(path).asScala) else None
+  def getListOpt(path: String): Option[Seq[ConfigValue]] = if(c.hasPath(path)) Some(c.getList(path).asScala.toSeq) else None
   def getStringListOpt(path: String): Option[Seq[String]] = Option(getStringListOr(path, null))
 
   def getStringOrStringList(path: String, default: => Vector[String] = Vector.empty): Vector[String] =

--- a/core/src/main/scala/com/novocode/ornate/js/JSResultConverter.scala
+++ b/core/src/main/scala/com/novocode/ornate/js/JSResultConverter.scala
@@ -2,7 +2,7 @@ package com.novocode.ornate.js
 
 import jdk.nashorn.api.scripting.JSObject
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 trait JSResultConverter[T] extends (AnyRef => T)
 trait JSMap {

--- a/core/src/main/scala/com/novocode/ornate/js/Modules.scala
+++ b/core/src/main/scala/com/novocode/ornate/js/Modules.scala
@@ -4,7 +4,7 @@ import com.novocode.ornate.Logging
 import org.slf4j.LoggerFactory
 
 import scala.collection.mutable
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import java.util.{ArrayList => JArrayList}
 import javax.script.{Bindings, ScriptContext, SimpleBindings}

--- a/core/src/main/scala/com/novocode/ornate/js/WebJarSupport.scala
+++ b/core/src/main/scala/com/novocode/ornate/js/WebJarSupport.scala
@@ -1,15 +1,17 @@
 package com.novocode.ornate.js
 
+import java.nio.charset.StandardCharsets
 import java.util.regex.Pattern
 
 import better.files._
+import org.apache.commons.compress.utils.IOUtils
 import org.slf4j.Logger
 import org.webjars.WebJarAssetLocator
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.io.Codec
 
-trait WebJarSupport {
+trait WebJarSupport extends Implicits {
   import WebJarSupport._
 
   def logger: Logger
@@ -17,7 +19,7 @@ trait WebJarSupport {
   def loadAsset(webjar: String, exactPath: String): Option[String] = getFullPathExact(webjar, exactPath).map { path =>
     logger.debug(s"Loading WebJar asset: $webjar/$exactPath")
     val in = getClass.getClassLoader.getResourceAsStream(path)
-    try in.content(Codec.UTF8).mkString finally in.close()
+    try new String(IOUtils.toByteArray(in), StandardCharsets.UTF_8) finally in.close()
   }
 }
 

--- a/core/src/main/scala/com/novocode/ornate/theme/HtmlTheme.scala
+++ b/core/src/main/scala/com/novocode/ornate/theme/HtmlTheme.scala
@@ -1,6 +1,7 @@
 package com.novocode.ornate.theme
 
 import java.net.{URI, URL}
+import java.nio.charset.StandardCharsets
 import java.text.Collator
 import java.util.{Collections, Comparator, Locale}
 
@@ -24,7 +25,7 @@ import org.commonmark.node._
 import play.twirl.api.{Html, HtmlFormat, Template1, TxtFormat}
 
 import scala.StringBuilder
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
@@ -60,7 +61,7 @@ class HtmlTheme(global: Global) extends Theme(global) { self =>
     wr.line
     wr.tag(htag, attrs)
     c.renderChildren(n)
-    wr.tag('/' + htag)
+    wr.tag('/'.toString + htag)
     wr.line
   }
 
@@ -331,7 +332,7 @@ class HtmlTheme(global: Global) extends Theme(global) { self =>
           val minifyInlineJS = minifyJS && !pc.features.isRequested(HtmlFeatures.MathJax) // HtmlCompressor cannot handle non-JavaScript <script> tags
           val min =
             if(minifyHTML) Util.htmlCompressorMinimize(formatted, minimizeCss = minifyCSS, minimizeJs = minifyInlineJS) else formatted+'\n'
-          file.write(min)(codec = Codec.UTF8)
+          file.write(min)(charset = StandardCharsets.UTF_8)
           Some(pm)
         } catch { case ex: Exception =>
           logger.error(s"Error rendering page ${p.uri} to $file", ex)
@@ -444,7 +445,7 @@ class HtmlTheme(global: Global) extends Theme(global) { self =>
   })
 }
 
-class HtmlFeatures(parents: Traversable[HtmlFeatures]) {
+class HtmlFeatures(parents: Iterable[HtmlFeatures]) {
   import HtmlFeatures._
 
   val requestedFeatures: mutable.Set[Feature] = mutable.Set[Feature]() ++= parents.flatMap(_.requestedFeatures)

--- a/core/src/main/scala/com/novocode/ornate/theme/default/DefaultTheme.scala
+++ b/core/src/main/scala/com/novocode/ornate/theme/default/DefaultTheme.scala
@@ -1,6 +1,7 @@
 package com.novocode.ornate.theme.default
 
 import java.net.{URI, URLDecoder}
+import java.nio.charset.StandardCharsets
 import java.util.Collections
 
 import com.novocode.ornate.commonmark._
@@ -15,7 +16,7 @@ import org.commonmark.ext.gfm.tables.TableBlock
 import org.commonmark.renderer.html.{HtmlNodeRendererContext, HtmlNodeRendererFactory, HtmlRenderer}
 import org.commonmark.node.{Block, Document, Node}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.io.Codec
 
 class DefaultTheme(global: Global) extends HtmlTheme(global) {
@@ -239,7 +240,7 @@ class DefaultSiteModel(theme: DefaultTheme, pms: Vector[HtmlPageModel]) extends 
     val css1 = themeConfig("global.cssFile").map { path =>
       val f = theme.global.getFile(path)
       try {
-        val s = f.contentAsString(Codec.UTF8)
+        val s = f.contentAsString(StandardCharsets.UTF_8)
         if(s.nonEmpty && !s.endsWith("\n")) s + "\n" else s
       } catch { case ex: Exception =>
         theme.logger.error("Error loading CSS file \""+path+"\" (resolved to \""+f+"\")", ex)

--- a/core/src/main/scala/com/novocode/ornate/theme/pdf/PdfTheme.scala
+++ b/core/src/main/scala/com/novocode/ornate/theme/pdf/PdfTheme.scala
@@ -16,7 +16,7 @@ import org.commonmark.ext.gfm.tables.TableBlock
 import org.commonmark.node.{Block, Node}
 import org.commonmark.renderer.html.{HtmlNodeRendererContext, HtmlNodeRendererFactory, HtmlRenderer}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class PdfTheme(global: Global) extends HtmlTheme(global) {
   def pdfTargetDir: File = super.targetDir

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.3.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.3.15")
+addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.4.2")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.8.0")
 


### PR DESCRIPTION
This allows me to build documentation site in slick project for each scala version at slick/slick#2106. 
```scala
  override lazy val projectSettings = inConfig(Ornate)(Defaults.configSettings) ++ Seq(
    ornateBaseDir := Some(sourceDirectory.value),
    ...
    libraryDependencies ++= Seq(
      BuildInfo.organization %% BuildInfo.name % BuildInfo.version % Ornate,
      "org.scala-lang" % "scala-library" % BuildInfo.scalaVersion % Ornate
    )
  )
```